### PR TITLE
Fix for speech text being white when using dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -73,6 +73,7 @@ h1 {
   padding: 10px;
   border-radius: 10px;
   text-align: left;
+  color: #213547;
   max-width: 400px;
   font-family:'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif
 }


### PR DESCRIPTION
Hi Dr. Hawkins, I looked into the white text issue (fixes #1)  and it turns out that the speech bubble text inherits the base html CSS properties, including the light / dark mode changes.

Since the speech bubble has a white background regardless of the browser theme, I decided to hardcode the text color within `.speechbubble` to the value that you set for dark-colored text. I believe CSS should have some way to set variables to avoid magic values... my experience with front-end is mostly with Android.